### PR TITLE
point readers to specific content in amplicon-docs

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -3,6 +3,7 @@
 
 As of QIIME 2 2025.10, q2-boots is included as part of the QIIME 2 distribution of [rachis](xref:rachis-news-target#q2f-transition) plugins.
 We therefore now refer you to [*Microbiome marker gene analysis with QIIME 2*](https://amplicon-docs.readthedocs.io/en/stable/) to learn how to use q2-boots.
+The [gut-to-soil tutorial](https://amplicon-docs.qiime2.org/en/stable/tutorials/gut-to-soil.html) provides an illustration of the usage of q2-boots in a real analysis, and the [q2-boots plugin index page](https://amplicon-docs.qiime2.org/en/stable/references/plugins/boots.html) provides reference content on the actions it provides. 
 These pages are staying here to avoid broken links from content that pre-dates this transition.
 
 ![](./_static/q2-boots-ai-art.png)


### PR DESCRIPTION
Added links to the gut-to-soil tutorial and q2-boots plugin index page for better guidance. These were previously contained on this site.