### PR TITLE
Use numpy.random.default_rng for seeding

### DIFF
--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -26,8 +26,8 @@ def resample(ctx: IContext,
     random_int = CaptureHolder.get_or_set(random_seed, get_np_random_seed)
 
     random.seed(random_int)
-    for _ in range(n):
-        _random_seed = random.randrange(NP_RNG_SIZE)
+    random_seeds = random.choices(NP_RNG_SIZE, k=n)
+    for _random_seed in random_seeds:
         resampled_table, = rarefy_action(table=table,
                                          sampling_depth=sampling_depth,
                                          with_replacement=replacement,

--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -26,7 +26,7 @@ def resample(ctx: IContext,
     random_int = CaptureHolder.get_or_set(random_seed, get_np_random_seed)
 
     random.seed(random_int)
-    random_seeds = random.choices(NP_RNG_SIZE, k=n)
+    random_seeds = random.choices(range(NP_RNG_SIZE), k=n)
     for _random_seed in random_seeds:
         resampled_table, = rarefy_action(table=table,
                                          sampling_depth=sampling_depth,

--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -21,15 +21,15 @@ def resample(ctx: IContext,
              random_seed: CaptureHolder[int] = None) -> \
         tuple[dict[str, Artifact]]:
     rarefy_action = ctx.get_action('feature_table', 'rarefy')
+
     resampled_tables = []
-
     random_int = CaptureHolder.get_or_set(random_seed, get_np_random_seed)
-
     random_state = RandomState(random_int)
+
     for _ in range(n):
         _random_seed = random_state.randint(NP_RNG_SIZE)
         resampled_table, = rarefy_action(table=table,
-                                         sampgitling_depth=sampling_depth,
+                                         sampling_depth=sampling_depth,
                                          with_replacement=replacement,
                                          random_seed=_random_seed)
         resampled_tables.append(resampled_table)

--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-from np.random import RandomState
+from numpy.random import RandomState
 
 from rachis import Artifact
 from rachis.plugin import (

--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-from numpy.random import RandomState
+from numpy.random import default_rng
 
 from rachis import Artifact
 from rachis.plugin import (
@@ -24,10 +24,9 @@ def resample(ctx: IContext,
 
     resampled_tables = []
     random_int = CaptureHolder.get_or_set(random_seed, get_np_random_seed)
-    random_state = RandomState(random_int)
-
-    for _ in range(n):
-        _random_seed = random_state.randint(NP_RNG_SIZE)
+    rng = default_rng(random_int)
+    random_seeds = rng.integers(low=0, high=NP_RNG_SIZE, size=n)
+    for _random_seed in random_seeds:
         resampled_table, = rarefy_action(table=table,
                                          sampling_depth=sampling_depth,
                                          with_replacement=replacement,

--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-import random
+from np.random import RandomState
 
 from rachis import Artifact
 from rachis.plugin import (
@@ -25,11 +25,11 @@ def resample(ctx: IContext,
 
     random_int = CaptureHolder.get_or_set(random_seed, get_np_random_seed)
 
-    random.seed(random_int)
-    random_seeds = random.choices(range(NP_RNG_SIZE), k=n)
-    for _random_seed in random_seeds:
+    random_state = RandomState(random_int)
+    for _ in range(n):
+        _random_seed = random_state.randint(NP_RNG_SIZE)
         resampled_table, = rarefy_action(table=table,
-                                         sampling_depth=sampling_depth,
+                                         sampgitling_depth=sampling_depth,
                                          with_replacement=replacement,
                                          random_seed=_random_seed)
         resampled_tables.append(resampled_table)


### PR DESCRIPTION
# Description
The test `test_rarefy_seed_cross_iteration` was failing on CI. I believe this had something to do with rng being advanced sometimes between iterations of the for loop inside of `resample`. I'm not positive how this was happening, I'm not sure if it could still happen between calling random.seed and random.choices. Near as I can tell pytest.xdist uses multiprocessing not multithreading and rng from different processes shouldn't be able to affect one another.

EDIT: Now using numpy.random.default_rng

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.