### PR TITLE
ENH: enable LinkedSequence as input to kmer_diversity

### DIFF
--- a/q2_boots/plugin_setup.py
+++ b/q2_boots/plugin_setup.py
@@ -13,7 +13,7 @@ from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence
 )
 from q2_types.feature_data import (
-    FeatureData, Sequence, RNASequence, ProteinSequence
+    FeatureData, Sequence, RNASequence, ProteinSequence, LinkedSequence
 )
 from q2_types.sample_data import AlphaDiversity, SampleData
 

--- a/q2_boots/plugin_setup.py
+++ b/q2_boots/plugin_setup.py
@@ -428,7 +428,8 @@ plugin.pipelines.register_function(
                                   PresenceAbsence],
             'sequences': FeatureData[Sequence |
                                      RNASequence |
-                                     ProteinSequence]},
+                                     ProteinSequence |
+                                     LinkedSequence]},
     parameters={
         'metadata': Metadata,
         'n': Int % Range(1, None),


### PR DESCRIPTION
DEPENDS ON: https://github.com/bokulich-lab/q2-kmerizer/pull/12

# Description
Adds `FeatureData[LinkedSequence]` as an optional input for `kmer_diversity`

# AI Disclosure
- [X] NO AI USED.
- [ ] AI USED.
