### PR TITLE
Revert "ENH: enable LinkedSequence as input to kmer_diversity"

### DIFF
--- a/q2_boots/plugin_setup.py
+++ b/q2_boots/plugin_setup.py
@@ -13,7 +13,7 @@ from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence
 )
 from q2_types.feature_data import (
-    FeatureData, Sequence, RNASequence, ProteinSequence, LinkedSequence
+    FeatureData, Sequence, RNASequence, ProteinSequence
 )
 from q2_types.sample_data import AlphaDiversity, SampleData
 
@@ -428,8 +428,7 @@ plugin.pipelines.register_function(
                                   PresenceAbsence],
             'sequences': FeatureData[Sequence |
                                      RNASequence |
-                                     ProteinSequence |
-                                     LinkedSequence]},
+                                     ProteinSequence]},
     parameters={
         'metadata': Metadata,
         'n': Int % Range(1, None),


### PR DESCRIPTION
Reverts qiime2/q2-boots#72, merged by accident

# AI Disclosure

- [X] NO AI USED.
- [ ] AI USED.