### PR TITLE
BUG: 128 bit random ints not being reliably generated in `kmer-diversity` pipeline

### DIFF
--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -5,10 +5,12 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-from numpy.random import default_rng
+from random import Random
 
 from rachis import Artifact
-from rachis.plugin import IContext, CaptureHolder, get_np_random_seed
+from rachis.plugin import (
+    IContext, CaptureHolder, get_np_random_seed, NP_RNG_BITS
+)
 
 
 def resample(ctx: IContext,
@@ -22,9 +24,8 @@ def resample(ctx: IContext,
 
     resampled_tables = []
     random_int = CaptureHolder.get_or_set(random_seed, get_np_random_seed)
-    rng = default_rng(random_int)
-    # The high here is unfortunately capped at 2**64 not 2**128
-    random_seeds = rng.integers(low=0, high=2**64, size=n)
+    rng = Random(random_int)
+    random_seeds = [rng.getrandbits(NP_RNG_BITS) for _ in range(n)]
     for _random_seed in random_seeds:
         resampled_table, = rarefy_action(table=table,
                                          sampling_depth=sampling_depth,

--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -8,9 +8,7 @@
 from numpy.random import default_rng
 
 from rachis import Artifact
-from rachis.plugin import (
-    IContext, CaptureHolder, get_np_random_seed
-)
+from rachis.plugin import IContext, CaptureHolder, get_np_random_seed
 
 
 def resample(ctx: IContext,

--- a/q2_boots/_resample.py
+++ b/q2_boots/_resample.py
@@ -9,7 +9,7 @@ from numpy.random import default_rng
 
 from rachis import Artifact
 from rachis.plugin import (
-    IContext, CaptureHolder, NP_RNG_SIZE, get_np_random_seed
+    IContext, CaptureHolder, get_np_random_seed
 )
 
 
@@ -25,7 +25,8 @@ def resample(ctx: IContext,
     resampled_tables = []
     random_int = CaptureHolder.get_or_set(random_seed, get_np_random_seed)
     rng = default_rng(random_int)
-    random_seeds = rng.integers(low=0, high=NP_RNG_SIZE, size=n)
+    # The high here is unfortunately capped at 2**64 not 2**128
+    random_seeds = rng.integers(low=0, high=2**64, size=n)
     for _random_seed in random_seeds:
         resampled_table, = rarefy_action(table=table,
                                          sampling_depth=sampling_depth,

--- a/q2_boots/tests/test_resample.py
+++ b/q2_boots/tests/test_resample.py
@@ -165,12 +165,11 @@ class ResampleTests(TestPluginBase):
             alias_yaml = yaml.safe_load(alias_fh)
             original_uuid = alias_yaml['action']['alias-of']
 
-        # original_path = qiime2.Cache().data / original_uuid
         original_action_yaml = (table._archiver.provenance_dir / 'artifacts' /
                                 original_uuid / 'action' / 'action.yaml')
         with open(original_action_yaml) as original_fh:
             # This triggers the error indicated in the PR pre fix
-            _ = yaml.safe_load(original_fh)
+            yaml.safe_load(original_fh)
 
         # Just show we got here
         self.assertTrue(True)

--- a/q2_boots/tests/test_resample.py
+++ b/q2_boots/tests/test_resample.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import yaml
 import pandas as pd
 
 import qiime2
@@ -146,6 +147,32 @@ class ResampleTests(TestPluginBase):
 
         self.assertTrue(_table_list_contains_different_tables(tables1))
         self.assertTrue(_table_list_contains_different_tables(tables3))
+
+    # This test is specifically to reproduce and show the fix for the issue
+    # fixed in https://github.com/qiime2/q2-boots/pull/75.
+    # Reproducing the issue requires the attempted reading of the action.yaml
+    # in an Artifact affected by the bad value for random_seed shown in that PR
+    # This test produces that behavior as directly as possible.
+    def test_rarefy_yaml_regression(self):
+        output = self.resample_pipeline(table=self.table_artifact2,
+                                        sampling_depth=1,
+                                        n=1,
+                                        replacement=True)
+
+        table = list(output.resampled_tables.values())[0]
+        alias_path = table._archiver.provenance_dir / 'action' / 'action.yaml'
+        with open(alias_path, 'r') as alias_fh:
+            alias_yaml = yaml.safe_load(alias_fh)
+            original_uuid = alias_yaml['action']['alias-of']
+
+        original_path = qiime2.Cache().data / original_uuid
+        with open(original_path / 'provenance' / 'action' / 'action.yaml') as \
+                original_fh:
+            # This triggers the error indicated in the PR pre fix
+            _ = yaml.safe_load(original_fh)
+
+        # Just show we got here
+        self.assertTrue(True)
 
     # test helper functions
     def _expected_sampling_depth(self, replacement):

--- a/q2_boots/tests/test_resample.py
+++ b/q2_boots/tests/test_resample.py
@@ -165,9 +165,10 @@ class ResampleTests(TestPluginBase):
             alias_yaml = yaml.safe_load(alias_fh)
             original_uuid = alias_yaml['action']['alias-of']
 
-        original_path = qiime2.Cache().data / original_uuid
-        with open(original_path / 'provenance' / 'action' / 'action.yaml') as \
-                original_fh:
+        # original_path = qiime2.Cache().data / original_uuid
+        original_action_yaml = (table._archiver.provenance_dir / 'artifacts' /
+                                original_uuid / 'action' / 'action.yaml')
+        with open(original_action_yaml) as original_fh:
             # This triggers the error indicated in the PR pre fix
             _ = yaml.safe_load(original_fh)
 


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
Get n 128 bit random ints reproducibly without causing nonsense in the action.yaml

The Traceback:
```
import pkg_resources
Traceback (most recent call last):
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/q2cli/commands.py", line 567, in call
results = self._execute_action(
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/q2cli/commands.py", line 645, in _execute_action
results = action(**arguments)
File "", line 2, in kmer_diversity
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/qiime2/sdk/action.py", line 241, in bound_callable
ctx = context_factory()
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/qiime2/sdk/action.py", line 289, in
callable_wrapper = self._bind(lambda: qiime2.sdk.Context(self))
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/qiime2/sdk/context/base.py", line 41, in init
self.cache.named_pool.create_index()
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/qiime2/core/cache.py", line 1843, in create_index
action_yaml = load_action_yaml(path)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/qiime2/core/util.py", line 477, in load_action_yaml
prov = yaml.safe_load(fh)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/init.py", line 125, in safe_load
return load(stream, SafeLoader)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/init.py", line 81, in load
return loader.get_single_data()
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/constructor.py", line 51, in get_single_data
return self.construct_document(node)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/constructor.py", line 60, in construct_document
for dummy in generator:
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/constructor.py", line 413, in construct_yaml_map
value = self.construct_mapping(node)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/constructor.py", line 218, in construct_mapping
return super().construct_mapping(node, deep=deep)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/constructor.py", line 143, in construct_mapping
value = self.construct_object(value_node, deep=deep)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/constructor.py", line 100, in construct_object
data = constructor(self, node)
File "/usr/local/Caskroom/miniforge/base/envs/q2-25.10/lib/python3.10/site-packages/yaml/constructor.py", line 427, in construct_undefined
raise ConstructorError(None, None,
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/apply:numpy._core.multiarray.scalar'
in "/var/folders/gt/s61zzgwx7gz_npzjm4gxfp3w0000gn/T/qiime2/elizabethgehret/data/f43be016-52a3-4055-85ba-2a89d838d3aa/provenance/action/action.yaml", line 19, column 22


Plugin error from boots:


could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/apply:numpy._core.multiarray.scalar'
in "/var/folders/gt/s61zzgwx7gz_npzjm4gxfp3w0000gn/T/qiime2/elizabethgehret/data/f43be016-52a3-4055-85ba-2a89d838d3aa/provenance/action/action.yaml", line 19, column 22
```
The thing in action.yaml coming from the old way of handling random ints in resample:
```
    -   random_seed: !!python/object/apply:numpy._core.multiarray.scalar
        - !!python/object/apply:numpy.dtype
            args:
            - i8
            - false
            - true
            state: !!python/tuple
            - 3
            - <
            - null
            - null
            - null
            - -1
            - -1
            - 0
        - !!binary |
            JAAAAAAAAAA=
```

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.