### PR TITLE
BUG: fix test failure due to q2-kmerizer changes in PR#12

### DIFF
--- a/q2_boots/tests/test_kmer_diversity.py
+++ b/q2_boots/tests/test_kmer_diversity.py
@@ -65,7 +65,9 @@ class KmerDiversityTests(TestPluginBase):
         self.assertEqual(len(output[1]), 10)
         for e in output[1].values():
             observed_table = e.view(pd.DataFrame)
-            self.assertTrue(observed_table.shape, (2, 90))
+            # modified 15 July 2026 from (2, 90) to accommodate changes in:
+            # https://github.com/bokulich-lab/q2-kmerizer/pull/12
+            self.assertEqual(observed_table.shape, (2, 94))
 
         # expected alpha vectors returned
         skbio_lt_060_alpha_keys = set(
@@ -74,7 +76,9 @@ class KmerDiversityTests(TestPluginBase):
             ['observed_features', 'pielou_e', 'shannon'])
         self.assertTrue(set(output[2].keys()) == skbio_lt_060_alpha_keys or
                         set(output[2].keys()) == skbio_gte_060_alpha_keys)
-        expected_obs_features = pd.Series([90.0, 65.0],
+        # modified 15 July 2026 from [90.0, 65.0] to accommodate changes in:
+        # https://github.com/bokulich-lab/q2-kmerizer/pull/12
+        expected_obs_features = pd.Series([94.0, 67.0],
                                           index=['S1', 'S2'],
                                           name='observed_features')
         observed_obs_features = output[2]['observed_features'].view(pd.Series)
@@ -85,8 +89,10 @@ class KmerDiversityTests(TestPluginBase):
         self.assertEqual(set(output[4].keys()), set(['jaccard', 'braycurtis']))
 
         # expected values calculated using set operations external to the tests
-        expected_jaccard = skbio.DistanceMatrix([[0, 0.27777778],
-                                                 [0.27777778, 0]],
+        # modified 15 July 2026 from 0.27777778 to accommodate changes in:
+        # https://github.com/bokulich-lab/q2-kmerizer/pull/12
+        expected_jaccard = skbio.DistanceMatrix([[0, 0.2872340425531915],
+                                                 [0.2872340425531915, 0]],
                                                 ids=['S1', 'S2'])
         observed_jaccard = output[3]['jaccard'].view(skbio.DistanceMatrix)
         pdt.assert_frame_equal(observed_jaccard.to_data_frame(),


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
This PR fixes failures in the modified test that were caused by changes in https://github.com/bokulich-lab/q2-kmerizer/pull/12. Now that terminal kmers are included, this changed the number of observed features as well as the jaccard distance (listing these two specifically because these are what is examined in the test). Below are my local reproductions of the updated values (first jaccard then observed features); I used the latest passed qiime2 environment (from 29 June) that includes dev installs of q2-boots, rachis and q2-kmerizer.

<img width="899" height="673" alt="kmer_diversity_test_checks" src="https://github.com/user-attachments/assets/ed57cbc2-0988-4dcf-a94d-768850ae59f5" />

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.
